### PR TITLE
Patch

### DIFF
--- a/PC-TransEngine.ini
+++ b/PC-TransEngine.ini
@@ -11,7 +11,7 @@ SpawnPrioritySeconds=1.0
 ServerTravelPause=4.0
 NetServerMaxTickRate=40
 LanServerMaxTickRate=60
-;; AllowPeerConnections=False
+AllowPeerConnections=False
 
 [IpDrv.ReservationBeacon]
 ConnectionTypeName=Demonware.ReservationBeaconConnectionDemonware

--- a/PC-TransEngine.ini
+++ b/PC-TransEngine.ini
@@ -9,8 +9,8 @@ MaxInternetClientRate=14000
 RelevantTimeout=5.0
 SpawnPrioritySeconds=1.0
 ServerTravelPause=4.0
-NetServerMaxTickRate=40
-LanServerMaxTickRate=60
+NetServerMaxTickRate=30
+LanServerMaxTickRate=35
 AllowPeerConnections=False
 
 [IpDrv.ReservationBeacon]

--- a/PC-TransEngine.ini
+++ b/PC-TransEngine.ini
@@ -26,3 +26,13 @@ ClientReceiveHeartbeatTimeoutConnected=10
 DisableAllHeartbeats=false
 DisableAsserts=true
 ;; reverting timeout threshold to patch 1.7 values
+
+[Engine.IniLocPatcher]
+DatastoresToRefresh=CurrentGame
+Files=(Filename="TransGame.int")
+Files=(Filename="TransWeapons.ini")
+Files=(Filename="TransCustomization.ini")
+Files=(Filename="TransLevels.ini")
+Files=(Filename="PC-TransGame.ini")
+Files=(Filename="PC-TransEngine.ini")
+Files=(Filename="PC-TransInput.ini") // <== Additional file needs to be patched in order to lock aim assist on mnk

--- a/PC-TransEngine.ini
+++ b/PC-TransEngine.ini
@@ -12,6 +12,7 @@ ServerTravelPause=4.0
 NetServerMaxTickRate=30
 LanServerMaxTickRate=35
 AllowPeerConnections=False
+;; Revert NetTickRate back to 30 to reduce horizontal ghostglitching & ghost bullets
 
 [IpDrv.ReservationBeacon]
 ConnectionTypeName=Demonware.ReservationBeaconConnectionDemonware

--- a/PC-TransGame.ini
+++ b/PC-TransGame.ini
@@ -72,26 +72,26 @@ EnableStandbyCheatDetection=false
 [TransGame.TnOnlineGameSettingsPartyPersistent]
 NumPublicConnections=20
 NumPrivateConnections=0
-EnableStandbyCheatDetection=true
+EnableStandbyCheatDetection=false
 
 [TransGame.TnOnlineGameSettingsPartyPresence]
 NumPublicConnections=20
 NumPrivateConnections=0
-EnableStandbyCheatDetection=true
+EnableStandbyCheatDetection=false
 
 [TransGame.TnOnlineGameSettingsPartyPersistentSV]
 PartyLobbyMapName=UI_Lobby_ESC_m
 PartyGameTeamStatus=GTS_SingleTeamGame
 NumPublicConnections=4
 NumPrivateConnections=0
-EnableStandbyCheatDetection=true
+EnableStandbyCheatDetection=false
 
 [TransGame.TnOnlineGameSettingsPartyPresenceSV]
 PartyLobbyMapName=UI_Lobby_ESC_m
 PartyGameTeamStatus=GTS_SingleTeamGame
 NumPublicConnections=4
 NumPrivateConnections=0
-EnableStandbyCheatDetection=true
+EnableStandbyCheatDetection=false
 
 [TransGame.TnOnlineGameSettingsKOTH]
 GameClass=TransContent.TnVersusGame

--- a/PC-TransGame.ini
+++ b/PC-TransGame.ini
@@ -41,7 +41,7 @@ _CountdownTime=60
 _RequirePlayersToBeConnected=true
 
 [TransContent.TnSurvivalGame]
-MaxPlayers=6
+MaxPlayers=4
 PlayerCanBeDowned=true
 MatchAutoStartCountdown=15
 SelfDamageMultiplier=0.25
@@ -67,7 +67,7 @@ MinRespawnDelay=3
 EmergencyDefaultMapId=1500
 ShouldPrestream=true
 ShouldSeamlessTravel=true
-EnableStandbyCheatDetection=true
+EnableStandbyCheatDetection=false
 
 [TransGame.TnOnlineGameSettingsPartyPersistent]
 NumPublicConnections=20
@@ -82,14 +82,14 @@ EnableStandbyCheatDetection=true
 [TransGame.TnOnlineGameSettingsPartyPersistentSV]
 PartyLobbyMapName=UI_Lobby_ESC_m
 PartyGameTeamStatus=GTS_SingleTeamGame
-NumPublicConnections=6
+NumPublicConnections=4
 NumPrivateConnections=0
 EnableStandbyCheatDetection=true
 
 [TransGame.TnOnlineGameSettingsPartyPresenceSV]
 PartyLobbyMapName=UI_Lobby_ESC_m
 PartyGameTeamStatus=GTS_SingleTeamGame
-NumPublicConnections=6
+NumPublicConnections=4
 NumPrivateConnections=0
 EnableStandbyCheatDetection=true
 
@@ -111,14 +111,13 @@ TimeLimits=1200
 
 
 [TransGame.TnOnlineGameSettingsDOMPublic]
-NumPublicConnections=12
+NumPublicConnections=20
 NumPrivateConnections=0
 AllowLobbyBestHostDeterminationHostMigration=false
-
 AllowLobbyHostMigration=false
 AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=false
-EnableStandbyCheatDetection=true
+EnableStandbyCheatDetection=false
 
 [TransGame.TnOnlineGameSettingsDOMPrivate]
 NumPublicConnections=0
@@ -138,13 +137,13 @@ TimeLimits=900
 TimeLimits=1200
 
 [TransGame.TnOnlineGameSettingsDMPublic]
-NumPublicConnections=12
+NumPublicConnections=20
 NumPrivateConnections=0
 AllowLobbyBestHostDeterminationHostMigration=false
 AllowLobbyHostMigration=false
 AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=false
-EnableStandbyCheatDetection=true
+EnableStandbyCheatDetection=false
 
 [TransGame.TnOnlineGameSettingsDMPrivate]
 NumPublicConnections=0
@@ -164,13 +163,13 @@ TimeLimits=900
 TimeLimits=1200
 
 [TransGame.TnOnlineGameSettingsTDMPublic]
-NumPublicConnections=12
+NumPublicConnections=20
 NumPrivateConnections=0
 AllowLobbyBestHostDeterminationHostMigration=false
 AllowLobbyHostMigration=false
 AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=false
-EnableStandbyCheatDetection=true
+EnableStandbyCheatDetection=false
 
 [TransGame.TnOnlineGameSettingsTDMPrivate]
 NumPublicConnections=0
@@ -202,7 +201,7 @@ EmergencyDefaultMapId=1600
 
 [TransGame.TnOnlineGameSettingsSVPrivate]
 NumPublicConnections=0
-NumPrivateConnections=6
+NumPrivateConnections=4
 AllowLobbyBestHostDeterminationHostMigration=false
 AllowLobbyHostMigration=false
 AllowInGameHostMigration=false
@@ -220,13 +219,13 @@ TimeLimits=900
 TimeLimits=1200
 
 [TransGame.TnOnlineGameSettingsCTFPublic]
-NumPublicConnections=12
+NumPublicConnections=20
 NumPrivateConnections=0
 AllowLobbyBestHostDeterminationHostMigration=false
 AllowLobbyHostMigration=false
 AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=false
-EnableStandbyCheatDetection=true
+EnableStandbyCheatDetection=false
 
 [TransGame.TnOnlineGameSettingsCTFPrivate]
 NumPublicConnections=0
@@ -252,7 +251,7 @@ AllowLobbyBestHostDeterminationHostMigration=false
 AllowLobbyHostMigration=false
 AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=false
-EnableStandbyCheatDetection=true
+EnableStandbyCheatDetection=false
 
 [TransGame.TnOnlineGameSettingsHHPrivate]
 NumPublicConnections=0

--- a/PC-TransGame.ini
+++ b/PC-TransGame.ini
@@ -114,8 +114,9 @@ TimeLimits=1200
 NumPublicConnections=12
 NumPrivateConnections=0
 AllowLobbyBestHostDeterminationHostMigration=false
-AllowLobbyHostMigration=true
-AllowInGameHostMigration=true
+
+AllowLobbyHostMigration=false
+AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=false
 EnableStandbyCheatDetection=true
 
@@ -140,8 +141,8 @@ TimeLimits=1200
 NumPublicConnections=12
 NumPrivateConnections=0
 AllowLobbyBestHostDeterminationHostMigration=false
-AllowLobbyHostMigration=true
-AllowInGameHostMigration=true
+AllowLobbyHostMigration=false
+AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=false
 EnableStandbyCheatDetection=true
 
@@ -166,8 +167,8 @@ TimeLimits=1200
 NumPublicConnections=12
 NumPrivateConnections=0
 AllowLobbyBestHostDeterminationHostMigration=false
-AllowLobbyHostMigration=true
-AllowInGameHostMigration=true
+AllowLobbyHostMigration=false
+AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=false
 EnableStandbyCheatDetection=true
 
@@ -193,8 +194,8 @@ ShouldSeamlessTravel=true
 NumPublicConnections=4
 NumPrivateConnections=0
 AllowLobbyBestHostDeterminationHostMigration=false
-AllowLobbyHostMigration=true
-AllowInGameHostMigration=true
+AllowLobbyHostMigration=false
+AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=true
 EnableStandbyCheatDetection=true
 EmergencyDefaultMapId=1600
@@ -222,8 +223,8 @@ TimeLimits=1200
 NumPublicConnections=12
 NumPrivateConnections=0
 AllowLobbyBestHostDeterminationHostMigration=false
-AllowLobbyHostMigration=true
-AllowInGameHostMigration=true
+AllowLobbyHostMigration=false
+AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=false
 EnableStandbyCheatDetection=true
 
@@ -248,8 +249,8 @@ TimeLimits=1200
 NumPublicConnections=12
 NumPrivateConnections=0
 AllowLobbyBestHostDeterminationHostMigration=false
-AllowLobbyHostMigration=true
-AllowInGameHostMigration=true
+AllowLobbyHostMigration=false
+AllowInGameHostMigration=false
 AllowInGameHostMigrationResultingInOnePlayer=false
 EnableStandbyCheatDetection=true
 

--- a/PC-TransInput.ini
+++ b/PC-TransInput.ini
@@ -5,4 +5,4 @@ MouseCameraSensitivityY=0.00114286
 MouseOrbitRotationCameraBehaviorSensitivityLow=0.03
 MouseOrbitRotationCameraBehaviorSensitivityHigh=0.2
 DisableTargetStickinessUnderMouseControl=true
-;; Permanently disable aim assist
+;; Permanently disable aim assist with mnk

--- a/PC-TransInput.ini
+++ b/PC-TransInput.ini
@@ -1,0 +1,7 @@
+[HM_Engine.HmPlayerInput]
+DeadZone=0.25
+MouseCameraSensitivityX=0.00114286
+MouseCameraSensitivityY=0.00114286
+MouseOrbitRotationCameraBehaviorSensitivityLow=0.03
+MouseOrbitRotationCameraBehaviorSensitivityHigh=0.2
+DisableTargetStickinessUnderMouseControl=true

--- a/PC-TransInput.ini
+++ b/PC-TransInput.ini
@@ -6,3 +6,4 @@ MouseOrbitRotationCameraBehaviorSensitivityLow=0.03
 MouseOrbitRotationCameraBehaviorSensitivityHigh=0.2
 DisableTargetStickinessUnderMouseControl=true
 ;; Permanently disable aim assist with mnk
+;; Requires PC-TransInput.ini to be added server-side within PC-TransEngine.ini

--- a/PC-TransInput.ini
+++ b/PC-TransInput.ini
@@ -5,3 +5,4 @@ MouseCameraSensitivityY=0.00114286
 MouseOrbitRotationCameraBehaviorSensitivityLow=0.03
 MouseOrbitRotationCameraBehaviorSensitivityHigh=0.2
 DisableTargetStickinessUnderMouseControl=true
+;; Permanently disable aim assist


### PR DESCRIPTION
- Revert NetTickRate to original state to reduce horizontal ghost-glitching & ghost bullets 
- Disable CheatDetection (anti-lagswitch, not needed for worldwide matchmaking)
- Increase number of public connections to lobby server-side
- Removed 2 extra unnecessary escalation players in config
- Lock aim assist on mouse server-side (Requires adding PC-TransInput.ini and an additional line added to IniLocPatcher within PC-TransEngine.ini)